### PR TITLE
Documentation fix

### DIFF
--- a/piston/steem.py
+++ b/piston/steem.py
@@ -660,7 +660,7 @@ class Steem(object):
     def transfer_to_vesting(self, amount, to=None, account=None):
         """ Vest STEEM
 
-            :param float amount: number of VESTS to withdraw over a period of 104 weeks
+            :param float amount: number of STEEM to vest
             :param str to: (optional) the source account for the transfer if not ``default_account``
             :param str account: (optional) the source account for the transfer if not ``default_account``
         """


### PR DESCRIPTION
Please correct me if I'm wrong. I believe there is a copy&paste mistake in the transfer_to_vesting function documentation. A withdraw takes 104 weeks, but a deposit should be instant, no?