### PR TITLE
Fix addPrivateKey to detect type properly AND owner/posting keys were mixed up

### DIFF
--- a/piston/steem.py
+++ b/piston/steem.py
@@ -695,9 +695,9 @@ class Steem(object):
                 "Call incomplete! Provide either a password or public keys!"
             )
 
-        owner   = format(posting_pubkey, prefix)
+        owner   = format(owner_pubkey, prefix)
         active  = format(active_pubkey, prefix)
-        posting = format(owner_pubkey, prefix)
+        posting = format(posting_pubkey, prefix)
         memo    = format(memo_pubkey, prefix)
 
         owner_key_authority = [[owner, 1]]

--- a/piston/wallet.py
+++ b/piston/wallet.py
@@ -246,7 +246,9 @@ class Wallet(LegacyWallet):
     def addPrivateKey(self, wif):
         """ Add a private key to the wallet database
         """
-        if isinstance(wif, PrivateKey):
+        # it could be either graphenebase or steembase so we can't check the type directly
+        keytypes = ["<class 'graphenebase.account.PrivateKey'>", "<class 'steembase.account.PrivateKey'>"]
+        if str(type(wif)) in keytypes:
             wif = str(wif)
         try:
             pub = format(PrivateKey(wif).pubkey, prefix)


### PR DESCRIPTION
I encountered the following error trying to create accounts with piston:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/site-packages/steem_piston-0.3-py3.5.egg/piston/wallet.py", line 257, in addPrivateKey
    pub = format(PrivateKey(wif).pubkey, prefix)
  File "/usr/local/lib/python3.5/site-packages/steembase/account.py", line 106, in __init__
    super(PrivateKey, self).__init__(wif, prefix)
  File "/usr/local/lib/python3.5/site-packages/graphenebase/account.py", line 307, in __init__
    self._wif = Base58(wif)
  File "/usr/local/lib/python3.5/site-packages/graphenebase/base58.py", line 39, in __init__
    if all(c in string.hexdigits for c in data) :
TypeError: 'PrivateKey' object is not iterable

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "test.py", line 3, in <module>
    s.create_account('REDACTED', creator='someguy123', password='REDACTED')
  File "/usr/local/lib/python3.5/site-packages/steem_piston-0.3-py3.5.egg/piston/steem.py", line 685, in create_account
    self.wallet.addPrivateKey(active_privkey)
  File "/usr/local/lib/python3.5/site-packages/steem_piston-0.3-py3.5.egg/piston/wallet.py", line 260, in addPrivateKey
    raise InvalidWifError("Invalid Private Key Format. Please use WIF!")
piston.wallet.InvalidWifError: Invalid Private Key Format. Please use WIF!
```

The issue was because you were checking the instanceOf against a Steembase PrivateKey, but the key which was passed in was actually a Graphenebase key. 

To solve this, I'm converting the type to a string and just checking against a list of class types. Fixes `create_account`